### PR TITLE
[pigeon] fix: make objcOptions optional

### DIFF
--- a/packages/pigeon/lib/pigeon_lib.dart
+++ b/packages/pigeon/lib/pigeon_lib.dart
@@ -1594,13 +1594,13 @@ ${_argParser.usage}''';
 
     if (options.objcHeaderOut != null) {
       options = options.merge(PigeonOptions(
-          objcOptions: options.objcOptions!.merge(ObjcOptions(
+          objcOptions: (options.objcOptions ?? ObjcOptions()).merge(ObjcOptions(
               headerIncludePath: path.basename(options.objcHeaderOut!)))));
     }
 
     if (options.cppHeaderOut != null) {
       options = options.merge(PigeonOptions(
-          cppOptions: options.cppOptions!.merge(CppOptions(
+          cppOptions: (options.cppOptions ?? CppOptions()).merge(CppOptions(
               headerIncludePath: path.basename(options.cppHeaderOut!)))));
     }
 


### PR DESCRIPTION
Since objcOptions and cppOptions are nullable, this makes it a bit safer. Could also be moved to the constructor.

Just a hotfix for making pigeon_build_runner work without a prefix for objc, as these lines throw a null exception right now,  but I made a PR to that plugin too to work around this: https://github.com/rotorgames/pigeon_build_runner/pull/1

This is such a minor change and not important enough for me to bother opening an issue.
More a heads up to the pigeon developer.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
